### PR TITLE
Enable OSX on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 os:
     - linux
+    - osx
 julia:
     - 0.3
     - 0.4


### PR DESCRIPTION
And upgrade travis settings.

Finally no deprecation warnings when loading PyPlot on master.... (after clearing the cache...)
