### PR TITLE
Fix depwarn on 0.5 for ByteString

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ interpolation](http://docs.julialang.org/en/latest/manual/strings/#interpolation
 (inserting the values of other variables into your string).
 
 Finally, you can use the lowest-level constructor
-`LaTeXString(s::ByteString)`.  The only advantage of this is that it
+`LaTeXString(s)`.  The only advantage of this is that it
 does *not* automatically put `$` at the beginning and end of the
 string.  So, if for some reason you want to use `text/latex` display
 of ordinary text (with no equations or formatting), you can use this

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-Compat 0.7.1
 julia 0.3
+Compat 0.7.15

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -4,6 +4,7 @@ module LaTeXStrings
 export LaTeXString, latexstring, @L_str, @L_mstr
 
 using Compat
+import Compat.String
 
 # IJulia supports LaTeX output for any object with a text/latex
 # writemime method, but these are annoying to type as string literals
@@ -12,18 +13,18 @@ using Compat
 # constructor, so that one can simply do L"$\alpha + \beta$".
 
 immutable LaTeXString <: AbstractString
-    s::ByteString
+    s::String
 end
 
 # coercing constructor:
-function latexstring(s::ByteString)
+function latexstring(s::String)
     # the only point of using LaTeXString to represent equations, since
     # IJulia doesn't support LaTeX output other than equations, so add $'s
     # around the string if they aren't there (ignoring \$)
     return ismatch(r"[^\\]\$|^\$", s) ?
         LaTeXString(s) :  LaTeXString(string("\$", s, "\$"))
 end
-latexstring(s::AbstractString) = latexstring(bytestring(s))
+latexstring(s::AbstractString) = latexstring(String(s))
 latexstring(args...) = latexstring(string(args...))
 
 macro L_str(s, flags...) latexstring(s) end


### PR DESCRIPTION
Requires JuliaLang/Compat.jl#192 and a new tag.