### PR TITLE
RFC: allow string interpolation in L"..."

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "LaTeXStrings"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.1.0"
+version = "1.2.0"
 
 [compat]
 julia = "1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Documenter", "Test"]

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -76,7 +76,7 @@ macro L_str(s::String)
             c = @inbounds s[i]
             if c === '$'
                 position(buf) > 0 && push!(ex.args, String(take!(buf)))
-                atom, i = parseatom(s, nextind(s, i), filename=__source__.file)
+                atom, i = parseatom(s, nextind(s, i), filename=string(__source__.file))
                 Meta.isexpr(atom, :incomplete) && error(atom.args[1])
                 atom !== nothing && push!(ex.args, atom)
                 continue

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -68,7 +68,7 @@ L"$x = 1.4142135623730951$"
 macro L_str(s::String)
     i = firstindex(s)
     buf = IOBuffer(maxsize=ncodeunits(s))
-    ex = Expr(:string)
+    ex = Expr(:call, GlobalRef(LaTeXStrings, :latexstring))
     while i <= ncodeunits(s)
         c = @inbounds s[i]
         i = nextind(s, i)
@@ -88,11 +88,7 @@ macro L_str(s::String)
         end
     end
     position(buf) > 0 && push!(ex.args, String(take!(buf)))
-    if !any(s -> s isa String && occursin(r"[^\\%]\$|^\$", s), ex.args)
-        pushfirst!(ex.args, '$')
-        push!(ex.args, '$')
-    end
-    return :(LaTeXString($(esc(ex))))
+    return esc(ex)
 end
 
 Base.write(io::IO, s::LaTeXString) = write(io, s.s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ end
         @test L"%$(x)%$x" == latexstring(x, x)
     end
     @test L"%$(1+2)" == latexstring(3)
+    @test L"%$(raw\"$$\")" == latexstring(raw"$$")
 
     if VERSION >= v"1.6.0-DEV.22"
         @test L"%$(@__FILE__)" == latexstring(@__FILE__)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
         @test L"%$(@__FILE__)" == latexstring(@__FILE__)
     end
 
-    @test_throws ErrorException var"@L_str"(
+    @test_throws ErrorException getproperty(LaTeXStrings, Symbol("@L_str"))(
         LineNumberNode(@__LINE__, @__FILE__), @__MODULE__,
         "%\$(",
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,30 @@ end
 # show should return nothing
 @test show(IOBuffer(), "application/x-latex", tst1) === nothing
 @test show(IOBuffer(), "text/latex", tst1) === nothing
+
+@testset "interpolation" begin
+    @test L"" == latexstring("")
+    @test L"%" == latexstring("%")
+    @test L"$" == latexstring("\$")
+    @test L"%$" == latexstring("")
+
+    for x in ["foo", 'c', 7, 3.1]
+        @test L"%$x" == latexstring(x)
+        @test L"%%$(x)foo" == latexstring("%", x, "foo")
+        @test L"%$(x)%$x" == latexstring(x, x)
+    end
+    @test L"%$(1+2)" == latexstring(3)
+
+    if VERSION >= v"1.6.0-DEV.22"
+        @test L"%$(@__FILE__)" == latexstring(@__FILE__)
+    end
+
+    @test_throws ErrorException var"@L_str"(
+        LineNumberNode(@__LINE__, @__FILE__), @__MODULE__,
+        "%\$(",
+    )
+end
+
+using Documenter
+DocMeta.setdocmeta!(LaTeXStrings, :DocTestSetup, :(using LaTeXStrings); recursive=true)
+doctest(LaTeXStrings; manual = false)


### PR DESCRIPTION
This uses `%$` for interpolation, as proposed by you in #27, which seems fine to me, but I'm happy to change it for something else. Still need to add docs and tests, but wanted to get a go-ahead on this approach first.
fixes #27