### PR TITLE
Pick up print_quoted_literal from Base

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -101,7 +101,7 @@ function Base.show(io::IO, s::LaTeXString)
         print(io,'"')
     else
         print(io, 'L')
-        print_quoted_literal(io, s.s)   # Julia < 1.6
+        Base.print_quoted_literal(io, s.s)   # Julia < 1.6
     end
 end
 

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -8,6 +8,7 @@ See in particular the `LaTeXString` type and the `L"..."` constructor macro.
 module LaTeXStrings
 export LaTeXString, latexstring, @L_str
 
+
 # IJulia supports LaTeX output for any object with a text/latex
 # writemime method, but these are annoying to type as string literals
 # in Julia because of all the escaping required, e.g. "\$\\alpha +
@@ -91,18 +92,22 @@ macro L_str(s::String)
     return esc(ex)
 end
 
+if isdefined(Base, :print_quoted_literal)
+    import Base.print_quoted_literal
+else
+    function print_quoted_literal(io,s)
+        print(io, '"')
+        Base.escape_raw_string(io,s)
+        print(io, '"')
+    end
+end
+
 Base.write(io::IO, s::LaTeXString) = write(io, s.s)
 Base.show(io::IO, ::MIME"application/x-latex", s::LaTeXString) = print(io, s.s)
 Base.show(io::IO, ::MIME"text/latex", s::LaTeXString) = print(io, s.s)
 function Base.show(io::IO, s::LaTeXString)
     print(io, "L")
     print_quoted_literal(io, s.s)
-end
-
-function print_quoted_literal(io, s::AbstractString)
-    print(io, '"')
-    for c = s; c == '"' ? print(io, "\\\"") : print(io, c); end
-    print(io, '"')
 end
 
 Base.firstindex(s::LaTeXString) = firstindex(s.s)

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -8,7 +8,6 @@ See in particular the `LaTeXString` type and the `L"..."` constructor macro.
 module LaTeXStrings
 export LaTeXString, latexstring, @L_str
 
-
 # IJulia supports LaTeX output for any object with a text/latex
 # writemime method, but these are annoying to type as string literals
 # in Julia because of all the escaping required, e.g. "\$\\alpha +

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -92,22 +92,18 @@ macro L_str(s::String)
     return esc(ex)
 end
 
-if isdefined(Base, :print_quoted_literal)
-    import Base.print_quoted_literal
-else
-    function print_quoted_literal(io,s)
-        print(io, '"')
-        Base.escape_raw_string(io,s)
-        print(io, '"')
-    end
-end
-
 Base.write(io::IO, s::LaTeXString) = write(io, s.s)
 Base.show(io::IO, ::MIME"application/x-latex", s::LaTeXString) = print(io, s.s)
 Base.show(io::IO, ::MIME"text/latex", s::LaTeXString) = print(io, s.s)
 function Base.show(io::IO, s::LaTeXString)
-    print(io, "L")
-    print_quoted_literal(io, s.s)
+    @static if isdefined(Base, :escape_raw_string)  # Julia ≥ 1.4
+        print(io,"L\"")
+        Base.escape_raw_string(io, s.s)
+        print(io,'"')
+    else
+        print(io, 'L')
+        print_quoted_literal(io, s.s)   # Julia < 1.6
+    end
 end
 
 Base.firstindex(s::LaTeXString) = firstindex(s.s)

--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -96,7 +96,13 @@ Base.show(io::IO, ::MIME"application/x-latex", s::LaTeXString) = print(io, s.s)
 Base.show(io::IO, ::MIME"text/latex", s::LaTeXString) = print(io, s.s)
 function Base.show(io::IO, s::LaTeXString)
     print(io, "L")
-    Base.print_quoted_literal(io, s.s)
+    print_quoted_literal(io, s.s)
+end
+
+function print_quoted_literal(io, s::AbstractString)
+    print(io, '"')
+    for c = s; c == '"' ? print(io, "\\\"") : print(io, c); end
+    print(io, '"')
 end
 
 Base.firstindex(s::LaTeXString) = firstindex(s.s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ tst1s = String(tst1)
 @test L"\alpha^2" == "\$\\alpha^2\$"
 @test repr("text/latex", tst1) == repr("application/x-latex", tst1) == tst1s
 @test sprint(show, "text/latex", tst1) == tst1s
+@test sprint(show, "text/plain", tst1) == "L\"an equation: \$\\alpha^2\$\""
 @test latexstring(tst1s) == tst1 == LaTeXString(tst1s)
 
 @test ccall(:strlen, Csize_t, (Cstring,), tst1) == ccall(:strlen, Csize_t, (Ptr{UInt8},), tst1) == sizeof(tst1)


### PR DESCRIPTION
Julia 1.6 removes `Base.print_quoted_literal`, breaking LaTeXStrings. It's a pretty small function though, so I just inserted it here.