### PR TITLE
update show

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -94,9 +94,17 @@ end
 Base.write(io::IO, s::LaTeXString) = write(io, s.s)
 Base.show(io::IO, ::MIME"application/x-latex", s::LaTeXString) = print(io, s.s)
 Base.show(io::IO, ::MIME"text/latex", s::LaTeXString) = print(io, s.s)
-function Base.show(io::IO, s::LaTeXString)
-    print(io, "L")
-    Base.print_quoted_literal(io, s.s)
+if VERSION >= v"1.6-"
+    function Base.show(io::IO, s::LaTeXString)
+        print(io, "L\"")
+        Base.escape_raw_string(io, s.s)
+        print(io, "\"")
+    end
+else
+    function Base.show(io::IO, s::LaTeXString)
+        print(io, "L")
+        Base.print_quoted_literal(io, s.s)
+    end
 end
 
 Base.firstindex(s::LaTeXString) = firstindex(s.s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ tst1s = String(tst1)
 @test repr("text/latex", tst1) == repr("application/x-latex", tst1) == tst1s
 @test sprint(show, "text/latex", tst1) == tst1s
 @test latexstring(tst1s) == tst1 == LaTeXString(tst1s)
+@test sprint(show, MIME("text/plain"), L"x") == "L\"\$x\$\""
 
 @test ccall(:strlen, Csize_t, (Cstring,), tst1) == ccall(:strlen, Csize_t, (Ptr{UInt8},), tst1) == sizeof(tst1)
 
@@ -51,6 +52,7 @@ end
         "%\$(",
     )
 end
+
 
 using Documenter
 DocMeta.setdocmeta!(LaTeXStrings, :DocTestSetup, :(using LaTeXStrings); recursive=true)


### PR DESCRIPTION
Base.print_quoted_literal does not exist in Julia 1.6