### PR TITLE
Add support for VSCode plot pane display.

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -105,6 +105,17 @@ function Base.show(io::IO, s::LaTeXString)
     end
 end
 
+Base.showable(::MIME"juliavscode/html", ::LaTeXString) = true
+function Base.repr(::MIME"juliavscode/html", s::LaTeXString)
+    mathjax_import_str = """
+      <script> MathJax = { tex: { displayMath: [['\$', '\$']] } }; </script>
+      <script src="/js/mathjax/tex-chtml.js" id="MathJax-script" async></script>
+      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+      """
+    return mathjax_import_str * s.s
+end
+
 Base.firstindex(s::LaTeXString) = firstindex(s.s)
 Base.lastindex(s::LaTeXString) = lastindex(s.s)
 Base.iterate(s::LaTeXString, i::Int) = iterate(s.s, i)


### PR DESCRIPTION
This PR would allow for a no-additional-dependencies way of getting `LaTeXStrings` rendered in the VSCode plot pane - if that is something you'd want to support.

I get that you are not interested in supporting rendering through lots of external dependencies (#43) and I agree with that. This suggestion is quite a bit lighter than that though - enable HTML display and prepend mathjax import to the string. 

I submitted a PR rather than an issue since that more clearly demonstrates what I had in mind. I'm overloading `Base.repr` because [VSCodeServer.jl seems to ignore the `Base.show` overload](https://github.com/julia-vscode/julia-vscode/blob/c747d812df0026e3e3ede1c802810d02aaad48cc/scripts/packages/VSCodeServer/src/display.jl#L47) that I started with. If you decide that this VSCode rendering functionality is worth having and that overloading `Base.repr` is strange, then I could have a chat with the VSCode people to see whether we should fix things such that LaTeXStrings.jl could overload `show` instead. 

Anyways, it works as it is now if you want to check it out. 

Cheers!
