### PR TITLE
Add match

### DIFF
--- a/src/LaTeXStrings.jl
+++ b/src/LaTeXStrings.jl
@@ -127,5 +127,6 @@ Base.isvalid(s::LaTeXString, i::Integer) = isvalid(s.s, i)
 Base.pointer(s::LaTeXString) = pointer(s.s)
 Base.IOBuffer(s::LaTeXString) = IOBuffer(s.s)
 Base.unsafe_convert(T::Union{Type{Ptr{UInt8}},Type{Ptr{Int8}},Cstring}, s::LaTeXString) = Base.unsafe_convert(T, s.s)
+Base.match(r::Regex, s::LaTeXString) = match(r, s.s)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ end
 @test codeunit(tst1, 1) == UInt8('a')
 @test L"foo"[1] == '$'
 @test tst1[1:2] == tst1[0x01:0x02] == tst1[[1,2]] == "an"
+@test match(r"o", L"foo").match == "o"
 
 # issue #23 — will change if #17 is addressed
 @test L"x" * L"y" == "\$x\$\$y\$"


### PR DESCRIPTION
I was checking how I could speed up loading my package with SnoopCompile and found that LaTeXStrings was causing 297 method invalidations:

```
inserting firstindex(s::LaTeXString) in LaTeXStrings at /home/rik/git/LaTeXStrings.jl/src/LaTeXStrings.jl:108 invalidated:
   backedges: 1: superseding firstindex(s::AbstractString) in Base at /nix/store/31534zna4n6p2s0jwadn8jl6lkvxqjch-julia_16/share/julia/base/strings/basic.jl:180 with MethodInstance for firstindex(::AbstractString) (297 children)
```

Specifically, the invalidation tree starts with

     firstindex(::AbstractString)
       match(::Regex, ::AbstractString)
         tryparse(::Type{VersionNumber}, ::AbstractString)

where `tryparse(::Type{VersionNumber}, ::AbstractString)` is an apparently not so type stable method in base. I'm trying to submit a patch to fix that but realized that we can also shortcut these invalidations by just defining `Base.match(r::Regex, s::LaTeXString) = match(r, s.s)` in this package (if I understand the principle of method invalidations correctly).
